### PR TITLE
Standardize repo layout to the shared standard

### DIFF
--- a/.claude/rules/status_conduct.md
+++ b/.claude/rules/status_conduct.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - ".status/**"
+---
+
+# Working in .status/
+
+- `.status/` is gitignored: the only copy is on this machine. Never delete,
+  move, or rewrite a file here without asking first. Appending is fine.
+- Every markdown file written here opens with a `For humans:` summary - three
+  or four sentences at the very top: what the file is and what a person needs
+  to take from it.
+- Nothing new is created at the `.status/` root. New material goes in
+  `plans/`, `prompts/`, `notes/`, or `scratch/`.
+- Only `plans/` and `prompts/` are edited in place. `notes/` is write-once.
+  `decisions.md` is append-only - never rewrite an entry.
+- Temporary scripts, experiments, and one-off test files go in
+  `.status/scratch/` - never the repository root. `scratch/` may hold any
+  file type and is deleted unread; everywhere else is markdown only.
+- Do not read `archive/` unless a file is named for you.
+- Filenames: lowercase ASCII, `_` as separator. Notes are
+  `YYYY-MM-DD_slug.md` (date first); plans and prompts are `slug.md` - no
+  date, no status word in the name.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "permissions": {
+    "allow": [
+      "Bash(validate_bids *)",
+      "Bash(python -c *)",
+      "Bash(python --version)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git show *)",
+      "Bash(git branch)",
+      "Bash(git ls-files *)",
+      "Bash(grep *)",
+      "Bash(ls)",
+      "Bash(ls *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(cat *)",
+      "Bash(wc *)"
+    ],
+
+    "ask": [
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout -- *)",
+      "Bash(git restore *)",
+      "Bash(git stash *)"
+    ],
+
+    "deny": [
+      "Read(.env)",
+      "Read(.envrc)",
+      "Read(.status/archive/**)",
+      "Bash(rm -rf *)",
+      "Bash(rm -r *)",
+      "Bash(git push)",
+      "Bash(git push *)",
+      "Bash(git reset --hard *)",
+      "Bash(pip install *)",
+      "Bash(python -m pip install *)",
+      "Bash(curl *)",
+      "Bash(wget *)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,10 @@
     "deny": [
       "Read(.env)",
       "Read(.envrc)",
+      "Bash(cat .env*)",
+      "Bash(head .env*)",
+      "Bash(tail .env*)",
+      "Bash(grep * .env*)",
       "Read(.status/archive/**)",
       "Bash(rm -rf *)",
       "Bash(rm -r *)",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,114 +1,18 @@
-# HED-examples developer instructions
+# hed-examples
 
-> **Local environment**: If `.status/local-environment.md` exists in this repository, check it first for machine-specific setup before running any commands. That file is gitignored and local-only.
+**`AGENTS.md` at the repository root is the instruction set for this project.
+Read it before answering, and follow it.**
 
-When you create markdown files, only capitalize the first letter of the first word in headings/titles.
+This file is a pointer and duplicates nothing. One source, several pointers: a
+rule stated in two files is a rule that will disagree with itself.
 
-## Repository overview
-This repository contains example datasets for the Hierarchical Event Descriptor (HED) system, including:
-- BIDS-formatted example datasets with HED annotations (in `datasets/`)
-- Lightweight test datasets with empty raw data files but intact metadata
+Path-specific instructions live in `.github/instructions/*.instructions.md`
+and load automatically when the files being worked on match their `applyTo`
+glob - for example, `status_conduct.instructions.md` applies under `.status/`.
+Nothing needs to reference them; this note exists so a reader knows they are
+there.
 
-## Project context
-- **Dataset Format**: BIDS-compatible with HED annotations
-- **Target Audience**: HED users learning to annotate and analyze data
-- **Repository Focus**: Example and test datasets
-
-## Key principles
-
-### 1. HED annotation standards
-- HED uses hierarchical, orthogonal vocabulary organized in tag trees
-- Tags are case-sensitive and use forward slashes for hierarchy (e.g., `Sensory-event/Visual/Color/Red`)
-- Groups use parentheses for semantic association
-- Definitions allow reusable annotation patterns with placeholders
-- Library schemas extend the standard schema with domain-specific vocabulary
-
-### 2. Dataset standards
-- All example datasets follow BIDS format with HED annotations
-- Datasets use empty raw data files to reduce size while maintaining metadata
-- Dataset names follow convention: `{modality}_ds{accession}{suffix}_{modifier}`
-  - Example: `eeg_ds003645s_hed` = EEG data from OpenNeuro ds003645 with HED annotations
-- Event files include HED annotations in JSON sidecars or TSV columns
-- All datasets should be validatable with bids-validator
-
-### 3. File organization
-- **datasets/**: BIDS-formatted example datasets with HED annotations
-- **`.status/`**: Temporary analysis and tracking files (gitignored — local only)
-- **docs/source/**: Documentation source files (currently empty)
-
-## Common tasks
-
-### When working with datasets
-- Validate datasets using bids-validator: `bids-validator {dataset_name} --config.ignore=99`
-- Check HED annotations in event JSON sidecars (`task-*_events.json`)
-- Verify event TSV files have proper structure
-- Ensure dataset_description.json includes HED version information
-- Test with hedtools validation before committing changes
-
-### When working with HED schemas
-- HED schema files are XML with `.xml` extension
-- Schema version format: `HED{major}.{minor}.{patch}.xml`
-- Use `load_schema_version()` to load specific versions
-- Latest stable schema: loaded with `load_schema_version(None)` or `load_schema_version('8.3.0')`
-- Library schemas: loaded with `load_schema_version('score_1.1.0')` format
-
-## Important conventions
-
-### HED syntax in examples
-- Use backticks for inline HED tags: `Sensory-event`
-- Use code blocks for multi-line HED strings:
-  ```hed
-  (Onset, Sensory-event, Visual-presentation, (Circle, Blue))
-  ```
-- Show both short form (e.g., `Red`) and long form when teaching concepts
-
-### Dataset references
-- Link to OpenNeuro for full datasets: `https://openneuro.org/datasets/ds{accession}`
-- Reference BIDS specification: `https://bids.neuroimaging.io/`
-- Include dataset table from `datasets/README.md` when describing multiple datasets
-
-## Setup and installation
-
-### Initial setup
-1. Install hedtools: `pip install hedtools` or `pip install git+https://github.com/hed-standard/hed-python/@main`
-2. Verify installation: `python -c "import hed; print(hed.__version__)"`
-
-### Validating datasets locally
-- Install hedtools (`pip install hedtools`) to get the `validate_bids` CLI tool
-- Run from repo root: `validate_bids datasets/{dataset_name} -s "*" --verbose`
-- Alternatively: `bids-validator datasets/{dataset_name} --config.ignore=99` (requires npm + bids-validator)
-- The `--config.ignore=99` flag ignores empty data files (all raw files in this repo are empty stubs)
-- FMRI datasets also need `--ignoreNiftiHeaders`
-
-## CI/CD workflows
-
-Two GitHub Actions workflows run on pull requests (defined in `.github/workflows/`):
-
-### `validate_examples.yml` — HED BIDS validation
-- **Triggers**: push or PR touching `datasets/**`
-- **Tool**: `hedtools` installed via `uv tool install hedtools`, runs `validate_bids` on every `datasets/*/` directory
-- **Must pass** for any PR that modifies dataset files
-
-### `typos.yaml` — spelling check
-- **Triggers**: push or PR to `main` (all files)
-- **Tool**: `uvx typos --config .typos.toml`
-- **Config**: `.typos.toml` at repo root — excludes `datasets/`, `.venv/`, `*.xml`, `*.svg`, `deprecated/`, etc.; allowlist words: `covert`, `hed`, `recuse`
-- **Must pass** for every PR — fix spelling errors before committing, or add legitimate terms to `.typos.toml` `[default.extend-words]`
-
-## Avoid
-- Don't modify dataset files without understanding BIDS structure
-- Don't commit large data files (datasets use empty stubs only)
-- Don't mix test/temporary files with example code (use `.status/` directory)
-
-## Related resources
-- [HED Resources Documentation](https://www.hedtags.org/hed-resources)
-- [HED Specification](https://www.hedtags.org/hed-specification)
-- [HED Schemas Repository](https://github.com/hed-standard/hed-schemas)
-- [HED Python Tools](https://github.com/hed-standard/hed-python)
-- [HED MATLAB Tools](https://github.com/hed-standard/hed-matlab)
-- [HED Standard Organization](https://github.com/hed-standard)
-- [BIDS Specification](https://bids.neuroimaging.io/)
-- [OpenNeuro](https://openneuro.org/)
-
----
-*This file provides context for GitHub Copilot to better assist with hed-examples development.*
+Machine-specific facts - interpreter, local paths, cache locations - are in
+`.status/local-environment.md`, which is gitignored: read it when it is there
+and ignore its absence when it is not. No committed file in this repository
+may contain a local path or a drive letter.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,8 +3,13 @@
 **`AGENTS.md` at the repository root is the instruction set for this project.
 Read it before answering, and follow it.**
 
-This file is a pointer and duplicates nothing. One source, several pointers: a
-rule stated in two files is a rule that will disagree with itself.
+This file is a pointer and duplicates no project rules. One source, several
+pointers: a rule stated in two files is a rule that will disagree with itself.
+The one deliberate exception is the path-scoped `.status/` conduct rules,
+which exist in two copies because each tool reads only its own format
+(`.claude/rules/status_conduct.md` for Claude Code,
+`.github/instructions/status_conduct.instructions.md` for Copilot); any change
+to one must be mirrored in the other.
 
 Path-specific instructions live in `.github/instructions/*.instructions.md`
 and load automatically when the files being worked on match their `applyTo`

--- a/.github/instructions/status_conduct.instructions.md
+++ b/.github/instructions/status_conduct.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: ".status/**"
+---
+
+# Working in .status/
+
+- `.status/` is gitignored: the only copy is on this machine. Never delete,
+  move, or rewrite a file here without asking first. Appending is fine.
+- Every markdown file written here opens with a `For humans:` summary - three
+  or four sentences at the very top: what the file is and what a person needs
+  to take from it.
+- Nothing new is created at the `.status/` root. New material goes in
+  `plans/`, `prompts/`, `notes/`, or `scratch/`.
+- Only `plans/` and `prompts/` are edited in place. `notes/` is write-once.
+  `decisions.md` is append-only - never rewrite an entry.
+- Temporary scripts, experiments, and one-off test files go in
+  `.status/scratch/` - never the repository root. `scratch/` may hold any
+  file type and is deleted unread; everywhere else is markdown only.
+- Do not read `archive/` unless a file is named for you.
+- Filenames: lowercase ASCII, `_` as separator. Notes are
+  `YYYY-MM-DD_slug.md` (date first); plans and prompts are `slug.md` - no
+  date, no status word in the name.

--- a/.gitignore
+++ b/.gitignore
@@ -106,8 +106,9 @@ docs/_build/
 # Pycharm
 .idea/
 
-# VS Code
-.vscode/
+# VS Code (settings.json is committed; everything else is personal)
+.vscode/*
+!.vscode/settings.json
 /venv/
 config.py
 .venv/
@@ -127,5 +128,16 @@ Desktop.ini
 schema_cache_test/
 hed_cache/
 **/remodel/summaries/*
-status/
+
+# Personal per-repo Claude Code notes (imports .status/local-environment.md)
+CLAUDE.local.md
+
+# Personal per-repo settings (absolute paths, claudeMdExcludes)
+.claude/settings.local.json
+
+# Real tokens and machine values
+.env
+
+# Working notes, plans, prompts, and decision records. Deliberately NOT
+# committed: this repo is public and .status/ holds half-formed thinking.
 .status/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ repositories (see below). There is no application code here.
 ## Commands
 
 Test framework: none - this is a dataset-only repo with no Python suite.
-Validation stands in for tests and CI runs it on every PR.
+Validation stands in for tests; CI runs it on every PR that changes
+`datasets/**` (spelling runs on every PR regardless).
 
 - Validate one dataset: `uvx --from hedtools validate_bids datasets/<name> -s "*"`
   (add `--verbose` for detail; CI installs hedtools with `uv tool install hedtools`
@@ -44,7 +45,7 @@ Validation stands in for tests and CI runs it on every PR.
 
 - HED tags are hierarchical with `/` separators, e.g.
   `Sensory-event/Visual-presentation`; however, preferred usage is the leaf tag.
-  groups use parentheses. Use backticks for inline HED tags in markdown.
+  Groups use parentheses. Use backticks for inline HED tags in markdown.
 - HED annotations live in JSON sidecars (`*_events.json`) or in a HED
   column of the events TSV - a dataset's choice between them is intentional;
   do not move annotations between the two.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# hed-examples
+
+Purpose: BIDS-formatted example datasets annotated with HED (Hierarchical
+Event Descriptors), used for lightweight software tests and as models for
+annotating real data.
+Not in scope: HED tools, schemas, or documentation - those live in their own
+repositories (see below). There is no application code here.
+
+## Commands
+
+Test framework: none - this is a dataset-only repo with no Python suite.
+Validation stands in for tests and CI runs it on every PR.
+
+- Validate one dataset: `uvx --from hedtools validate_bids datasets/<name> -s "*"`
+  (add `--verbose` for detail; CI installs hedtools with `uv tool install hedtools`
+  and runs `validate_bids` on every `datasets/*/` directory)
+- Spell check: `uvx typos --config .typos.toml`
+- Alternative validator: `bids-validator datasets/<name> --config.ignore=99`
+  (requires npm; add `--ignoreNiftiHeaders` for fMRI datasets; the ignore flag
+  suppresses the empty-file error - all raw files here are empty stubs)
+
+## Layout
+
+- `datasets/` - the BIDS example datasets, one directory each; the table in
+  `datasets/README.md` describes them
+- `.github/workflows/` - CI: `validate_examples.yml` (HED validation, runs on
+  changes to `datasets/**`) and `typos.yaml` (spelling, runs on everything)
+- `.status/` - working notes. Gitignored; local to each machine.
+
+## Conventions that differ from defaults
+
+- **ASCII only** in prose, code, comments, and filenames: `-` not em or en
+  dashes, `->` not arrows, `...` not an ellipsis character, straight quotes.
+  Exception: genuine data (author names, dataset titles, recorded API
+  responses) keeps whatever characters it actually contains.
+- Markdown headings capitalize only the first word, proper nouns, and acronyms.
+- Dataset names follow `{modality}_ds{accession}{suffix}_{modifier}`, e.g.
+  `eeg_ds003645s_hed` = EEG data from OpenNeuro ds003645, reduced ('s'), with
+  HED annotations. Datasets derived from OpenNeuro keep the accession number.
+- Raw data files are deliberately empty stubs; metadata and headers are real.
+  Never commit actual data.
+
+## Rules that are easy to get wrong
+
+- HED tags are hierarchical with `/` separators, e.g.
+  `Sensory-event/Visual-presentation`; however, preferred usage is the leaf tag.
+  groups use parentheses. Use backticks for inline HED tags in markdown.
+- HED annotations live in JSON sidecars (`*_events.json`) or in a HED
+  column of the events TSV - a dataset's choice between them is intentional;
+  do not move annotations between the two.
+- Column order in `events.tsv` files is significant - never reorder.
+- `dataset_description.json` must include the HED version; validation reads it.
+- A spelling CI failure is fixed by correcting the typo or, for a legitimate
+  term, adding it to `[default.extend-words]` in `.typos.toml` - never by
+  excluding the file.
+
+## Related repositories
+
+- `hed-python` - the hedtools package that provides `validate_bids`
+- `hed-schemas` - the HED schema (vocabulary) XML files
+- `hed-specification` and `hed-resources` (www.hedtags.org) - the docs
+
+None are vendored here; a session that needs one must be granted access to
+that checkout.
+
+## Where the thinking lives
+
+`.status/` is gitignored, so it exists only on the machine that wrote it and
+never in a fresh clone or worktree.
+
+- `.status/README.md` - the index. Read this first; it lists what is active.
+- `.status/decisions.md` - why things are the way they are. Read before
+  proposing structural changes. Append entries; never rewrite one.
+- `.status/plans/*.md` - active plans. Check the `Status:` header and the
+  `[ ]` / `[x]` markers before starting work.
+- `.status/local-environment.md` - this machine's paths, interpreter, and
+  quirks. Tool-agnostic. Never copy its contents into a committed file.
+- IMPORTANT: do not read `.status/archive/` unless a file is named for you.
+  Nothing new is created at the `.status/` root.
+
+## Working agreements
+
+- IMPORTANT: every file written to `.status/` opens with a `For humans:`
+  summary - three or four sentences, at the very top: what the file is and
+  what a person needs to take from it. The same applies to a long answer in a
+  session: lead with the conclusion.
+- IMPORTANT: temporary scripts, experiments, and one-off test files go in
+  `.status/scratch/` - **never the repository root**.
+- Show evidence, not assertions: the command that was run and its actual
+  output. For dataset work, counts and a sample of records.
+- Never push; the maintainer does the pushes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+@AGENTS.md
+
+# Claude Code
+
+- Path-scoped rules live in `.claude/rules/` and load automatically when a
+  session touches files matching their `paths:` globs - for example,
+  `status_conduct.md` applies under `.status/`. Nothing needs to reference
+  them; this note exists so a reader knows they are there.
+- `CLAUDE.local.md` (gitignored) holds notes about this machine's Claude Code
+  setup and imports `.status/local-environment.md`, which is where machine
+  facts live for every tool, not just this one.
+- After changing either import, run `/context` and confirm the file appears
+  under **Memory files**.


### PR DESCRIPTION
- Add AGENTS.md as the single instruction file (Test framework: none - dataset-only repo; validate_bids stands in for tests)
- Add CLAUDE.md as the @AGENTS.md import plus Claude Code notes
- Reduce .github/copilot-instructions.md to a pointer at AGENTS.md
- Add .claude/settings.json (portable permissions; .env and .status/archive reads denied) and .claude/rules/status_conduct.md with its .github/instructions/ Copilot twin
- Commit .vscode/settings.json (eol, whitespace, final newline)
- Extend .gitignore: .env, CLAUDE.local.md, .claude/settings.local.json; narrow .vscode/ so settings.json is tracked; drop dead status/ entry